### PR TITLE
Match init middleware to react-document

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,13 @@ The `session` object that is passed to the middleware has the following API:
 ```ts
 interface Session {
   on: OnRender
-  htmlProps: any
-  headProps: any
-  window: any
+  htmlProps: { [key: string]: string }
+  bodyProps: { [key: string]: string }
+  window: { [key: string]: any }
+  head: ReactElement<any>[]
+  footer: ReactElement<any>[]
+  css: string[]
+  js: string[]
 }
 
 type OnRender = 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
       "!**/__mocks__/**",
       "!**/__tests__/**"
     ],
+    "coverageReporters": [
+      "json"
+    ],
     "transform": {
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },

--- a/packages/react-chain-helmet/package.json
+++ b/packages/react-chain-helmet/package.json
@@ -17,7 +17,8 @@
     "test": "../../node_modules/.bin/jest"
   },
   "devDependencies": {
-    "@types/react-helmet": "^5.0.0"
+    "@types/react-helmet": "^5.0.0",
+    "react-chain": "^0.3.1"
   },
   "peerDependencies": {
     "react": "^15.4.2"

--- a/packages/react-chain-helmet/src/ReactChainHelmet.ts
+++ b/packages/react-chain-helmet/src/ReactChainHelmet.ts
@@ -1,9 +1,8 @@
 import Helmet from 'react-helmet'
-import { Middleware } from 'react-chain/lib/ReactChain'
-import { SessionT } from 'react-chain/lib/Session'
 import { HelmetData } from 'react-helmet'
+import { MiddlewareT, SessionT } from 'react-chain/lib/types'
 
-const helmet = (): Middleware => (session: SessionT & {
+const helmet = (): MiddlewareT => (session: SessionT & {
   helmet: HelmetData,
 }) => {
   session.on('server', render => {

--- a/packages/react-chain-helmet/src/ReactChainHelmet.ts
+++ b/packages/react-chain-helmet/src/ReactChainHelmet.ts
@@ -1,10 +1,14 @@
 import Helmet from 'react-helmet'
 import { Middleware } from 'react-chain/lib/ReactChain'
+import { SessionT } from 'react-chain/lib/Session'
+import { HelmetData } from 'react-helmet'
 
-const helmet = (): Middleware => session => {
-  session.on('server', (render: Function) => {
+const helmet = (): Middleware => (session: SessionT & {
+  helmet: HelmetData,
+}) => {
+  session.on('server', render => {
     render()
-    session.helmet = Helmet.rewind()
+    session.helmet = Helmet.renderStatic()
   })
 }
 

--- a/packages/react-chain-helmet/src/ReactChainHelmet.ts
+++ b/packages/react-chain-helmet/src/ReactChainHelmet.ts
@@ -1,9 +1,10 @@
 import Helmet from 'react-helmet'
+import { Middleware } from 'react-chain/lib/ReactChain'
 
-const helmet = () => (session: any) => {
+const helmet = (): Middleware => session => {
   session.on('server', (render: Function) => {
     render()
-    session.headProps.helmet = Helmet.rewind()
+    session.helmet = Helmet.rewind()
   })
 }
 

--- a/packages/react-chain-helmet/src/__mocks__/react-helmet.js
+++ b/packages/react-chain-helmet/src/__mocks__/react-helmet.js
@@ -1,7 +1,7 @@
 const reactHelmet = jest.genMockFromModule('react-helmet')
 
-reactHelmet.rewind = function () {
-  return true
+reactHelmet.renderStatic = function () {
+  return {}
 }
 
 module.exports.default = reactHelmet

--- a/packages/react-chain-helmet/src/__tests__/ReactChainHelmet-test.ts
+++ b/packages/react-chain-helmet/src/__tests__/ReactChainHelmet-test.ts
@@ -12,7 +12,7 @@ describe('react-chain-helmet', () => {
     expect(typeof session).toBe('function')
   })
 
-  it('should call render and modify the context on server render', done => {
+  it('should call unfoldRender and modify the context on server unfoldRender', done => {
     const next = jest.fn()
     const on = jest.fn((_, render) => {
       render(next)

--- a/packages/react-chain-helmet/src/__tests__/ReactChainHelmet-test.ts
+++ b/packages/react-chain-helmet/src/__tests__/ReactChainHelmet-test.ts
@@ -14,16 +14,13 @@ describe('react-chain-helmet', () => {
 
   it('should call render and modify the context on server render', done => {
     const next = jest.fn()
-    const on = jest.fn((target, render) => {
+    const on = jest.fn((_, render) => {
       render(next)
-      expect(sessionMock.headProps).toHaveProperty('helmet', true)
+      expect(sessionMock).toHaveProperty('helmet', {})
       expect(next).toHaveBeenCalled()
       done()
     })
-    const sessionMock = {
-      on,
-      headProps: {},
-    }
-    chainHelmet()(sessionMock)
+    const sessionMock = { on }
+    chainHelmet()(sessionMock as any)
   })
 })

--- a/packages/react-chain-history/package.json
+++ b/packages/react-chain-history/package.json
@@ -17,7 +17,8 @@
     "test": "../../node_modules/.bin/jest"
   },
   "devDependencies": {
-    "@types/history": "^4.5.0"
+    "@types/history": "^4.5.0",
+    "react-chain": "^0.3.1"
   },
   "dependencies": {
     "history": "^4.6.1",

--- a/packages/react-chain-history/src/ReactChainHistory.tsx
+++ b/packages/react-chain-history/src/ReactChainHistory.tsx
@@ -2,29 +2,29 @@ import * as React from 'react'
 import createBrowserHistory from 'history/createBrowserHistory'
 import createMemoryHistory from 'history/createMemoryHistory'
 import HistoryProvider from './HistoryProvider'
+import { SessionT } from 'react-chain/lib/Session'
+import { History } from 'history'
 
-const history = () => (session: any) => {
-  let history: any
-
+export default () => (session: SessionT & {
+  history: History
+}) => {
   if (session.req) {
-    history = createMemoryHistory()
+    session.history = createMemoryHistory()
   } else {
-    history = createBrowserHistory()
-    history.listen(() => {
-      session.refresh()
+    session.history = createBrowserHistory()
+    session.history.listen(() => {
+      if (session.refresh) {
+        session.refresh()
+      }
     })
   }
-
-  session.history = history
 
   return async (next: () => any) => {
     const children = await next()
     return (
-      <HistoryProvider history={history}>
+      <HistoryProvider history={session.history}>
         {children}
       </HistoryProvider>
     )
   }
 }
-
-export default history

--- a/packages/react-chain-history/src/ReactChainHistory.tsx
+++ b/packages/react-chain-history/src/ReactChainHistory.tsx
@@ -2,12 +2,12 @@ import * as React from 'react'
 import createBrowserHistory from 'history/createBrowserHistory'
 import createMemoryHistory from 'history/createMemoryHistory'
 import HistoryProvider from './HistoryProvider'
-import { SessionT } from 'react-chain/lib/Session'
 import { History } from 'history'
+import { CreateElementT, SessionT } from 'react-chain/lib/types'
 
 export default () => (session: SessionT & {
   history: History
-}) => {
+}): CreateElementT => {
   if (session.req) {
     session.history = createMemoryHistory()
   } else {
@@ -19,7 +19,7 @@ export default () => (session: SessionT & {
     })
   }
 
-  return async (next: () => any) => {
+  return async next => {
     const children = await next()
     return (
       <HistoryProvider history={session.history}>

--- a/packages/react-chain-history/src/__tests__/ReactChainHistory-test.tsx
+++ b/packages/react-chain-history/src/__tests__/ReactChainHistory-test.tsx
@@ -2,6 +2,7 @@ import chainHistory from '../ReactChainHistory'
 import HistoryProvider from '../HistoryProvider'
 import * as React from 'react'
 import { shallow } from 'enzyme'
+import { WrapElement } from '../../../react-chain/src/ReactChain'
 
 describe('react-chain-history', () => {
   it('should be a function', () => {
@@ -11,7 +12,7 @@ describe('react-chain-history', () => {
   it('should wrap an element in the HistoryProvider', async () => {
     const history = chainHistory()
     const refresh = jest.fn()
-    const element = await history({ refresh })(() => <div />)
+    const element = await history({ refresh } as any)(() => <div />)
 
     expect(shallow(element).instance()).toBeInstanceOf(HistoryProvider)
   })
@@ -22,7 +23,7 @@ describe('react-chain-history', () => {
       refresh: jest.fn(),
     }
 
-    await history(session)(() => <div />)
+    await history(session as any)(() => <div />)
 
     expect(session).toHaveProperty('history')
   })
@@ -38,7 +39,7 @@ describe('react-chain-history', () => {
     })
 
     it('should have a listen method on the history', async () => {
-      await history(session)(render)
+      await history(session as any)(render)
       expect(session.history).toHaveProperty('listen')
       expect(typeof session.history.listen).toBe('function')
     })

--- a/packages/react-chain-history/src/__tests__/ReactChainHistory-test.tsx
+++ b/packages/react-chain-history/src/__tests__/ReactChainHistory-test.tsx
@@ -2,7 +2,7 @@ import chainHistory from '../ReactChainHistory'
 import HistoryProvider from '../HistoryProvider'
 import * as React from 'react'
 import { shallow } from 'enzyme'
-import { WrapElement } from '../../../react-chain/src/ReactChain'
+import { CreateElementT } from 'react-chain/lib/types'
 
 describe('react-chain-history', () => {
   it('should be a function', () => {
@@ -12,7 +12,7 @@ describe('react-chain-history', () => {
   it('should wrap an element in the HistoryProvider', async () => {
     const history = chainHistory()
     const refresh = jest.fn()
-    const element = await history({ refresh } as any)(() => <div />)
+    const element = await history({ refresh } as any)(async () => <div />)
 
     expect(shallow(element).instance()).toBeInstanceOf(HistoryProvider)
   })
@@ -23,13 +23,13 @@ describe('react-chain-history', () => {
       refresh: jest.fn(),
     }
 
-    await history(session as any)(() => <div />)
+    await history(session as any)(async () => <div />)
 
     expect(session).toHaveProperty('history')
   })
 
   describe('browser', () => {
-    const render = () => (<div />)
+    const render = async () => (<div />)
     let history = chainHistory()
     let session: any
 
@@ -51,7 +51,7 @@ describe('react-chain-history', () => {
   })
 
   describe('server', () => {
-    const render = () => <div />
+    const render = async () => <div />
     let session: any
 
     beforeEach(() => {

--- a/packages/react-chain/src/ReactChain.ts
+++ b/packages/react-chain/src/ReactChain.ts
@@ -1,6 +1,6 @@
 import createSession from './Session'
 import { ReactElement } from 'react'
-import { validateElementCreator, render, renderElementChain } from './utils'
+import { validateElementCreator, unfoldRender, renderElementChain } from './utils'
 import provide from './ReactChainProvider'
 import reactChainInitMiddleware from './ReactChainInit'
 import { MiddlewareT, SessionT, CreateElementT } from './types'
@@ -41,7 +41,7 @@ export class ReactChain {
 
   async renderBrowser(session: SessionT, onRender: (element: ReactElement<any>) => void) {
     const element = await this.getElement(session)
-    render(session, 'browser')(() => {
+    unfoldRender(session, 'browser', () => {
       onRender(element)
     })
   }
@@ -49,7 +49,7 @@ export class ReactChain {
   async renderServer(session: SessionT, onRender: (element: ReactElement<any>) => string) {
     const element = await this.getElement(session)
     let body = ''
-    render(session, 'server')(() => {
+    unfoldRender(session, 'server', () => {
       body = onRender(element)
     })
     return body

--- a/packages/react-chain/src/ReactChain.ts
+++ b/packages/react-chain/src/ReactChain.ts
@@ -1,7 +1,7 @@
 import createSession from './Session'
 import { ReactElement } from 'react'
 import { validateElementCreator, unfoldRender, renderElementChain } from './utils'
-import provide from './ReactChainProvider'
+import reactChainProvider from './ReactChainProvider'
 import reactChainInitMiddleware from './ReactChainInit'
 import { MiddlewareT, SessionT, CreateElementT } from './types'
 
@@ -36,7 +36,7 @@ export class ReactChain {
       session.__firstRender = false
     }
 
-    return await provide(renderElementChain(session.__elementChain), session)
+    return await reactChainProvider(renderElementChain(session.__elementChain), session)
   }
 
   async renderBrowser(session: SessionT, onRender: (element: ReactElement<any>) => void) {

--- a/packages/react-chain/src/ReactChainInit.ts
+++ b/packages/react-chain/src/ReactChainInit.ts
@@ -1,9 +1,15 @@
 import { Middleware } from './ReactChain'
 
 const reactChainInitMiddleware: Middleware = session => {
-  session.htmlProps = {}
-  session.headProps = {}
-  session.window = {}
+  Object.defineProperties(session, {
+    htmlProps: { enumerable: true, writable: true, value: {} },
+    bodyProps: { enumerable: true, writable: true, value: {} },
+    window: { enumerable: true, writable: true, value: {} },
+    head: { enumerable: true, writable: true, value: [] },
+    footer: { enumerable: true, writable: true, value: [] },
+    css: { enumerable: true, writable: true, value: [] },
+    js: { enumerable: true, writable: true, value: [] },
+  })
 }
 
 export default reactChainInitMiddleware

--- a/packages/react-chain/src/ReactChainInit.ts
+++ b/packages/react-chain/src/ReactChainInit.ts
@@ -1,6 +1,6 @@
-import { Middleware } from './ReactChain'
+import { MiddlewareT } from './types'
 
-const reactChainInitMiddleware: Middleware = session => {
+const reactChainInitMiddleware: MiddlewareT = session => {
   Object.defineProperties(session, {
     htmlProps: { enumerable: true, writable: true, value: {} },
     bodyProps: { enumerable: true, writable: true, value: {} },

--- a/packages/react-chain/src/ReactChainProvider.tsx
+++ b/packages/react-chain/src/ReactChainProvider.tsx
@@ -1,21 +1,12 @@
 import * as React from 'react'
-import { SessionT } from './Session'
+import { AwaitNextT, SessionT } from './types'
 
-export type Props = {
+export class ReactChainProvider extends React.Component<{
   context: SessionT,
   nextContext?: SessionT,
   children?: any,
-}
-
-export type RenderChildren =
-  null | (() => Promise<React.ReactElement<any>>)
-
-export class ReactChainProvider extends React.Component<Props, any> {
-  static childContextTypes = {
-    htmlProps: React.PropTypes.object.isRequired,
-    headProps: React.PropTypes.object.isRequired,
-    window: React.PropTypes.object.isRequired,
-  }
+}, any> {
+  static childContextTypes = {}
 
   getChildContext() {
     return this.props.nextContext
@@ -26,7 +17,7 @@ export class ReactChainProvider extends React.Component<Props, any> {
   }
 }
 
-export default async function createBase(next: RenderChildren, context: SessionT) {
-  const element = next && await next()
+export default async function createBase(next: AwaitNextT, context: SessionT) {
+  const element = await next()
   return React.createElement(ReactChainProvider, { context }, element)
 }

--- a/packages/react-chain/src/ReactChainProvider.tsx
+++ b/packages/react-chain/src/ReactChainProvider.tsx
@@ -18,6 +18,8 @@ export class ReactChainProvider extends React.Component<{
 }
 
 export default async function createBase(next: AwaitNextT, context: SessionT) {
-  const element = await next()
-  return React.createElement(ReactChainProvider, { context }, element)
+  return React.createElement(ReactChainProvider, { context }, typeof next === 'function'
+    ? await next()
+    : null
+  )
 }

--- a/packages/react-chain/src/ReactChainProvider.tsx
+++ b/packages/react-chain/src/ReactChainProvider.tsx
@@ -26,7 +26,6 @@ export class ReactChainProvider extends React.Component<Props, any> {
   }
 }
 
-
 export default async function createBase(next: RenderChildren, context: SessionT) {
   const element = next && await next()
   return React.createElement(ReactChainProvider, { context }, element)

--- a/packages/react-chain/src/Session.ts
+++ b/packages/react-chain/src/Session.ts
@@ -3,11 +3,7 @@ import { getChainForTarget } from './SessionUtils'
 import reactChainProvider from './ReactChainProvider'
 import { ReactElement } from 'react'
 
-export type ExcessT = Partial<{
-  [key: string]: any
-}>
-
-export type SessionT = {
+export interface SessionT {
   readonly __browserChain: WrapRender[]
   readonly __serverChain: WrapRender[]
   readonly __elementChain: WrapElement[]
@@ -20,7 +16,10 @@ export type SessionT = {
   footer: ReactElement<any>[]
   css: string[]
   js: string[]
-} & ExcessT
+  refresh?: Function
+  req?: any
+  res?: any
+}
 
 export default function(): SessionT {
   const session = Object.create({}, {

--- a/packages/react-chain/src/Session.ts
+++ b/packages/react-chain/src/Session.ts
@@ -1,4 +1,4 @@
-import { getChainForTarget } from './SessionUtils'
+import { getChainForTarget } from './utils'
 import { RenderTargetT, SessionT, WrapRenderCallT } from './types'
 
 export default function(): SessionT {

--- a/packages/react-chain/src/Session.ts
+++ b/packages/react-chain/src/Session.ts
@@ -1,15 +1,26 @@
 import { WrapRender, RenderTarget, WrapElement } from './ReactChain'
 import { getChainForTarget } from './SessionUtils'
 import reactChainProvider from './ReactChainProvider'
+import { ReactElement } from 'react'
 
-export interface SessionT {
+export type ExcessT = Partial<{
+  [key: string]: any
+}>
+
+export type SessionT = {
   readonly __browserChain: WrapRender[]
   readonly __serverChain: WrapRender[]
   readonly __elementChain: WrapElement[]
   readonly on: (target?: RenderTarget, render?: WrapRender) => void
   __firstRender: boolean
-  [key: string]: any
-}
+  htmlProps: { [key: string]: string }
+  bodyProps: { [key: string]: string }
+  window: { [key: string]: any }
+  head: ReactElement<any>[]
+  footer: ReactElement<any>[]
+  css: string[]
+  js: string[]
+} & ExcessT
 
 export default function(): SessionT {
   const session = Object.create({}, {

--- a/packages/react-chain/src/Session.ts
+++ b/packages/react-chain/src/Session.ts
@@ -1,36 +1,16 @@
-import { WrapRender, RenderTarget, WrapElement } from './ReactChain'
 import { getChainForTarget } from './SessionUtils'
-import reactChainProvider from './ReactChainProvider'
-import { ReactElement } from 'react'
-
-export interface SessionT {
-  readonly __browserChain: WrapRender[]
-  readonly __serverChain: WrapRender[]
-  readonly __elementChain: WrapElement[]
-  readonly on: (target?: RenderTarget, render?: WrapRender) => void
-  __firstRender: boolean
-  htmlProps: { [key: string]: string }
-  bodyProps: { [key: string]: string }
-  window: { [key: string]: any }
-  head: ReactElement<any>[]
-  footer: ReactElement<any>[]
-  css: string[]
-  js: string[]
-  refresh?: Function
-  req?: any
-  res?: any
-}
+import { RenderTargetT, SessionT, WrapRenderCallT } from './types'
 
 export default function(): SessionT {
   const session = Object.create({}, {
     __browserChain: { value: [] },
     __serverChain: { value: [] },
-    __elementChain: { value: [reactChainProvider] },
+    __elementChain: { value: [] },
     __firstRender: { value: true, writable: true },
   })
 
   return Object.defineProperty(session, 'on', {
-    value(target?: RenderTarget, render?: WrapRender) {
+    value(target?: RenderTargetT, render?: WrapRenderCallT) {
       const chain = getChainForTarget(session, target)
 
       if (typeof render !== 'function') {

--- a/packages/react-chain/src/SessionUtils.ts
+++ b/packages/react-chain/src/SessionUtils.ts
@@ -1,9 +1,8 @@
-import { WrapRender, RenderTarget } from './ReactChain'
-import { SessionT } from './Session'
+import { RenderTargetT, SessionT, WrapRenderCallT } from './types'
 
 export function getChainForTarget(
   session: SessionT,
-  target?: RenderTarget,
+  target?: RenderTargetT,
 ) {
   switch (target) {
     case 'browser':
@@ -18,7 +17,7 @@ export function getChainForTarget(
   }
 }
 
-export function renderRecursively(wrappers: WrapRender[], onComplete: Function) {
+export function renderRecursively(wrappers: WrapRenderCallT[], onComplete: Function) {
   let index = 0
 
   if (wrappers.length === 0) {
@@ -48,7 +47,7 @@ export function renderRecursively(wrappers: WrapRender[], onComplete: Function) 
   }
 }
 
-export function render(session: SessionT, target: RenderTarget) {
+export function render(session: SessionT, target: RenderTargetT) {
   const chain = getChainForTarget(session, target)
   return (onComplete = () => {}) => renderRecursively(chain, onComplete)
 }

--- a/packages/react-chain/src/__tests__/ReactChain-test.tsx
+++ b/packages/react-chain/src/__tests__/ReactChain-test.tsx
@@ -1,9 +1,10 @@
-import createReactChain, { ReactChain } from '../ReactChain'
-import createSession, { SessionT } from '../Session'
 import * as React from 'react'
+import createReactChain, { ReactChain } from '../ReactChain'
+import createSession from '../Session'
 import { shallow } from 'enzyme'
 import { ReactChainProvider } from '../ReactChainProvider'
 import reactChainInitMiddleware from '../ReactChainInit'
+import { SessionT } from '../types'
 
 describe('ReactChain', () => {
   let app: ReactChain

--- a/packages/react-chain/src/__tests__/ReactChain-test.tsx
+++ b/packages/react-chain/src/__tests__/ReactChain-test.tsx
@@ -39,11 +39,11 @@ describe('ReactChain', () => {
     })
 
     it('should have mutable props', async () => {
-      app.chain(session => {
+      app.chain((session: any) => {
         session.someEdit = 'someEdit'
       })
 
-      app.chain(session => {
+      app.chain((session: any) => {
         session.someEdit += ' anotherEdit'
       })
 

--- a/packages/react-chain/src/__tests__/ReactChainInit-test.ts
+++ b/packages/react-chain/src/__tests__/ReactChainInit-test.ts
@@ -6,11 +6,21 @@ describe('ReactChainInit', () => {
     expect(typeof middleware).toBe('function')
   })
 
-  it('should add `htmlProps`, `headProps` and `window` properties as objects', () => {
-    const fakeSession = createSession()
-    middleware(fakeSession)
-    expect(fakeSession).toHaveProperty('htmlProps')
-    expect(fakeSession).toHaveProperty('headProps')
-    expect(fakeSession).toHaveProperty('window')
+  it('should add non-configurable properties', () => {
+    const props = [
+      'htmlProps',
+      'bodyProps',
+      'window',
+      'head',
+      'footer',
+      'css',
+      'js',
+    ]
+    const session = createSession()
+    middleware(session)
+    props.forEach(prop => {
+      expect(session).toHaveProperty(prop)
+      expect(() => delete session[prop]).toThrowErrorMatchingSnapshot()
+    })
   })
 })

--- a/packages/react-chain/src/__tests__/ReactChainInit-test.ts
+++ b/packages/react-chain/src/__tests__/ReactChainInit-test.ts
@@ -16,7 +16,7 @@ describe('ReactChainInit', () => {
       'css',
       'js',
     ]
-    const session = createSession()
+    const session = createSession() as any
     middleware(session)
     props.forEach(prop => {
       expect(session).toHaveProperty(prop)

--- a/packages/react-chain/src/__tests__/Session-test.tsx
+++ b/packages/react-chain/src/__tests__/Session-test.tsx
@@ -1,7 +1,7 @@
 import createSession, { SessionT } from '../Session'
-import * as React from 'react'
 import reactChainProvider from '../ReactChainProvider'
 import { render } from '../SessionUtils'
+import 'react'
 
 describe('Session', () => {
   let session: SessionT
@@ -23,13 +23,14 @@ describe('Session', () => {
   })
 
   it('should have readonly properties', () => {
-    const props = ['__elementChain', '__browserChain', '__serverChain', 'on']
+    const props: Array<keyof SessionT> = ['__elementChain', '__browserChain', '__serverChain', 'on']
+    const fakeSession = createSession() as any
     let initial: any
     props.forEach(prop => {
-      initial = session[prop]
+      initial = fakeSession[prop]
       expect(initial).toBeDefined()
       expect(() => {
-        session[prop] = 'fake'
+        fakeSession[prop] = 'fake'
       }).toThrowErrorMatchingSnapshot()
     })
   })
@@ -101,19 +102,22 @@ describe('Session', () => {
   })
 
   it('can modify the exposed instance', () => {
-    session.on('browser', render => {
-      session.someEdit = 'someEdit'
+    let fakeSession: SessionT & { someEdit?: string }
+    fakeSession = createSession()
+
+    fakeSession.on('browser', render => {
+      fakeSession.someEdit = 'someEdit'
       render()
     })
 
-    session.on('browser', render => {
-      session.someEdit += ' anotherEdit'
+    fakeSession.on('browser', render => {
+      fakeSession.someEdit += ' anotherEdit'
       render()
     })
 
-    render(session, 'browser')()
+    render(fakeSession, 'browser')()
 
-    expect(session).toHaveProperty('someEdit', 'someEdit anotherEdit')
+    expect(fakeSession).toHaveProperty('someEdit', 'someEdit anotherEdit')
   })
 
   it('should have a render chain that starts with createReactChainProvider', () => {

--- a/packages/react-chain/src/__tests__/Session-test.tsx
+++ b/packages/react-chain/src/__tests__/Session-test.tsx
@@ -1,6 +1,6 @@
 import 'react'
 import createSession from '../Session'
-import { render } from '../SessionUtils'
+import { render } from '../utils'
 import { SessionT } from '../types'
 
 describe('Session', () => {

--- a/packages/react-chain/src/__tests__/Session-test.tsx
+++ b/packages/react-chain/src/__tests__/Session-test.tsx
@@ -1,7 +1,7 @@
-import createSession, { SessionT } from '../Session'
-import reactChainProvider from '../ReactChainProvider'
-import { render } from '../SessionUtils'
 import 'react'
+import createSession from '../Session'
+import { render } from '../SessionUtils'
+import { SessionT } from '../types'
 
 describe('Session', () => {
   let session: SessionT
@@ -118,9 +118,5 @@ describe('Session', () => {
     render(fakeSession, 'browser')()
 
     expect(fakeSession).toHaveProperty('someEdit', 'someEdit anotherEdit')
-  })
-
-  it('should have a render chain that starts with createReactChainProvider', () => {
-    expect(session).toHaveProperty('__elementChain', [reactChainProvider])
   })
 })

--- a/packages/react-chain/src/__tests__/Session-test.tsx
+++ b/packages/react-chain/src/__tests__/Session-test.tsx
@@ -1,6 +1,6 @@
 import 'react'
 import createSession from '../Session'
-import { render } from '../utils'
+import { unfoldRender } from '../utils'
 import { SessionT } from '../types'
 
 describe('Session', () => {
@@ -63,11 +63,11 @@ describe('Session', () => {
       serverCallOrder.push('SERVER_RENDER_2')
     })
 
-    render(session, 'browser')(() => {
+    unfoldRender(session, 'browser', () => {
       browserCallOrder.push('ACTUAL_RENDER')
     })
 
-    render(session, 'server')(() => {
+    unfoldRender(session, 'server', () => {
       serverCallOrder.push('ACTUAL_RENDER')
       return ''
     })
@@ -89,7 +89,7 @@ describe('Session', () => {
     ])
   })
 
-  it('should throw if fails to call render', () => {
+  it('should throw if fails to call render callback', () => {
     session.on('browser', render => {
       render()
     })
@@ -97,7 +97,7 @@ describe('Session', () => {
     session.on('browser', render => { })
 
     expect(() => {
-      render(session, 'browser')()
+      unfoldRender(session, 'browser')
     }).toThrow()
   })
 
@@ -115,7 +115,7 @@ describe('Session', () => {
       render()
     })
 
-    render(fakeSession, 'browser')()
+    unfoldRender(fakeSession, 'browser')
 
     expect(fakeSession).toHaveProperty('someEdit', 'someEdit anotherEdit')
   })

--- a/packages/react-chain/src/__tests__/__snapshots__/ReactChain-test.tsx.snap
+++ b/packages/react-chain/src/__tests__/__snapshots__/ReactChain-test.tsx.snap
@@ -8,4 +8,4 @@ exports[`ReactChain .getElement() should throw when a middleware returns a React
 
 exports[`ReactChain .getElement() should throw when a middleware returns a wrong type 1`] = `[Error: .chain(): A session wrap can return a 'next' function or void, instead returns 'ReactElement'.]`;
 
-exports[`ReactChain .renderServer() should pass the element to the render callback 1`] = `"{\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"context\\":{\\"htmlProps\\":{},\\"headProps\\":{},\\"window\\":{}},\\"children\\":null},\\"_owner\\":null,\\"_store\\":{}}"`;
+exports[`ReactChain .renderServer() should pass the element to the render callback 1`] = `"{\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"context\\":{\\"htmlProps\\":{},\\"bodyProps\\":{},\\"window\\":{},\\"head\\":[],\\"footer\\":[],\\"css\\":[],\\"js\\":[]},\\"children\\":null},\\"_owner\\":null,\\"_store\\":{}}"`;

--- a/packages/react-chain/src/__tests__/__snapshots__/ReactChainInit-test.ts.snap
+++ b/packages/react-chain/src/__tests__/__snapshots__/ReactChainInit-test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReactChainInit should add non-configurable properties 1`] = `"Cannot delete property 'htmlProps' of #<Object>"`;
+
+exports[`ReactChainInit should add non-configurable properties 2`] = `"Cannot delete property 'bodyProps' of #<Object>"`;
+
+exports[`ReactChainInit should add non-configurable properties 3`] = `"Cannot delete property 'window' of #<Object>"`;
+
+exports[`ReactChainInit should add non-configurable properties 4`] = `"Cannot delete property 'head' of #<Object>"`;
+
+exports[`ReactChainInit should add non-configurable properties 5`] = `"Cannot delete property 'footer' of #<Object>"`;
+
+exports[`ReactChainInit should add non-configurable properties 6`] = `"Cannot delete property 'css' of #<Object>"`;
+
+exports[`ReactChainInit should add non-configurable properties 7`] = `"Cannot delete property 'js' of #<Object>"`;

--- a/packages/react-chain/src/types.ts
+++ b/packages/react-chain/src/types.ts
@@ -1,0 +1,38 @@
+import { ReactElement } from 'react'
+
+export type RenderTargetT =
+  'browser' |
+  'server'
+
+export type AwaitNextT =
+  () => Promise<null | ReactElement<any>>
+
+export type CreateElementT =
+  (next: AwaitNextT) =>
+    ReactElement<any> | Promise<ReactElement<any>>
+
+export type WrapRenderCallT =
+  (render: Function) =>
+    void
+
+export type MiddlewareT =
+  (session: SessionT) =>
+    (void | CreateElementT)
+
+export interface SessionT {
+  readonly __browserChain: WrapRenderCallT[]
+  readonly __serverChain: WrapRenderCallT[]
+  readonly __elementChain: CreateElementT[]
+  readonly on: (target?: RenderTargetT, render?: WrapRenderCallT) => void
+  __firstRender: boolean
+  htmlProps: { [key: string]: string }
+  bodyProps: { [key: string]: string }
+  window: { [key: string]: any }
+  head: ReactElement<any>[]
+  footer: ReactElement<any>[]
+  css: string[]
+  js: string[]
+  refresh?: Function
+  req?: any
+  res?: any
+}

--- a/packages/react-chain/src/types.ts
+++ b/packages/react-chain/src/types.ts
@@ -5,7 +5,7 @@ export type RenderTargetT =
   'server'
 
 export type AwaitNextT =
-  () => Promise<null | ReactElement<any>>
+  () => null | Promise<ReactElement<any>>
 
 export type CreateElementT =
   (next: AwaitNextT) =>

--- a/packages/react-chain/src/utils.ts
+++ b/packages/react-chain/src/utils.ts
@@ -78,7 +78,7 @@ export function renderRecursively(wrappers: WrapRenderCallT[], onComplete: Funct
   }
 }
 
-export function render(session: SessionT, target: RenderTargetT) {
+export function unfoldRender(session: SessionT, target: RenderTargetT, onComplete = () => {}) {
   const chain = getChainForTarget(session, target)
-  return (onComplete = () => {}) => renderRecursively(chain, onComplete)
+  renderRecursively(chain, onComplete)
 }


### PR DESCRIPTION
This pull request matches the props on `SessionT` to [`react-document`](https://github.com/aranja/react-document)'s component props, making it easier to render final component SSR with session data. These props are not configurable. Note that I did leave out some properties that are (AFAIK) irrelevant to react-chain.

Additionally, I fixed the type definitions and did some mild refactoring. I moved much of the error checks and validator code into the utilities module. This is mainly done so that it will be simpler in a future pull request to add a environment check and do dead code elimination in a production build.